### PR TITLE
Allow for multiple concurrent quests [#339]

### DIFF
--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -3,7 +3,7 @@ style="background-color: white; min-height: 100px">
 
     <!-- Quests header -->
     <h6 style="display:inline">
-        <span class='' data-bind='text: "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
+        <span class='' data-bind='text: !player.tutorialComplete() ? "Tutorial Quest" : "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
         </span>
     </h6>
     <button class='btn btn-sm btn-primary' style="margin:5px"

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -7,7 +7,7 @@ style="background-color: white; min-height: 100px">
         </span>
     </h6>
     <button class='btn btn-sm btn-primary' style="margin:5px"
-            data-bind='click: function(){$("#QuestModal").modal("show")}'>
+            data-bind='visible: player.tutorialComplete(), click: function(){$("#QuestModal").modal("show")}'>
         Quest List
     </button>
 

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -19,7 +19,7 @@ style="background-color: white; min-height: 100px">
                 <div class="col-sm-11 col-md-8">
                     <div class="row" style="margin-bottom: 10px">
                         <div class="col-9" style="padding:0px; margin:0px">
-                            <div class="progress" style="padding:0px; text-align:center" 
+                            <div class="progress" style="margin-top:6px; padding:0px; text-align:center" 
                                 data-bind='tooltip: {title: QuestHelper.questList()[$data.index].progressText, trigger: "hover"}'>
                                 <div class="progress-bar bg-success" role="progressbar" 
                                     data-bind="attr:{style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
@@ -28,7 +28,7 @@ style="background-color: white; min-height: 100px">
                             </div>
                         </div>
                         <div class="col-3">
-                            <button style="margin:0px; padding:0px; min-width:60px"
+                            <button style="margin:0px; padding:0px; height:20px; min-width:60px"
                                     data-bind='
                                         click: function(){QuestHelper.questList()[$data.index].exit();}, 
                                         text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit", 

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -1,42 +1,41 @@
 <div class="page-item" id="questDisplayContainer"
 style="background-color: white; min-height: 100px">
-    <br>
-    <button style="vertical-align: middle;" class='btn btn-primary'
-            data-bind='visible: (player.tutorialProgress() == 6) && !player.currentQuest(),
-                                   text: "New Quest",
-                                   click: function(){$("#QuestModal").modal("show")}'>
-    </button>
-    <div data-bind='if: (player.tutorialProgress() == 6) && player.currentQuest()'>
-        <p data-bind='text: QuestHelper.questList()[player.currentQuest().index].description'></p>
-        <div class="row justify-content-center">
-            <div class="col-10">
-                <div class="progress"
-                     data-bind='tooltip: {title: ko.pureComputed(function(){return QuestHelper.questList()[player.currentQuest().index].progressText()}), trigger: "hover"}'>
-                    <div class="progress-bar bg-success" role="progressbar"
-                         data-bind="attr:{ style: 'width:' + (QuestHelper.questList()[player.currentQuest().index].progress() * 100) + '%' }"
-                         aria-valuemin="0" aria-valuemax="100">
-                    </div>
-                </div>
-                <div>
-                                <span data-bind='if: QuestHelper.questList()[player.currentQuest().index].isCompleted()'>
-                                    <button class='btn btn-sm btn-success'
-                                            data-bind='click: function(){QuestHelper.questList()[player.currentQuest().index].claimReward()}'>
-                                        Claim
-                                    </button>
-                                </span>
-                    <span>
-                                    <button class='btn btn-sm btn-primary' style="margin:5px"
-                                            data-bind='click: function(){$("#QuestModal").modal("show")}'>
-                                        Questlist
-                                    </button>
-                                </span>
-                    <span data-bind='if: !QuestHelper.questList()[player.currentQuest().index].isCompleted()'>
-                                    <button class='btn btn-sm btn-danger' style="margin:5px"
-                                            data-bind='click: function(){QuestHelper.quitQuest()}'>
-                                        Quit
-                                    </button>
-                                </span>
 
+    <!-- Quests header -->
+    <h6 style="display:inline">
+        <span class='' data-bind='text: "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
+        </span>
+    </h6>
+    <button class='btn btn-sm btn-primary' style="margin:5px"
+            data-bind='click: function(){$("#QuestModal").modal("show")}'>
+        Quest List
+    </button>
+
+    <!-- List of quests -->
+    <div data-bind="foreach: player.currentQuests">
+        <div class="card border-bottom-0">
+            <p style="margin-bottom: 0px" data-bind="text: QuestHelper.questList()[$data.index].description"></p>
+            <div class="row justify-content-sm-center">
+                <div class="col-sm-11 col-md-8">
+                    <div class="row" style="margin-bottom: 10px">
+                        <div class="col-9" style="padding:0px; margin:0px">
+                            <div class="progress" style="padding:0px; text-align:center" 
+                                data-bind='tooltip: {title: QuestHelper.questList()[$data.index].progressText, trigger: "hover"}'>
+                                <div class="progress-bar bg-success" role="progressbar" 
+                                    data-bind="attr:{style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
+                                    aria-valuemin="0" aria-valuemax="100">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-3">
+                            <button style="margin:0px; padding:0px; min-width:60px"
+                                    data-bind='
+                                        click: function(){QuestHelper.questList()[$data.index].exit();}, 
+                                        text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit", 
+                                        attr: {class: QuestHelper.questList()[$data.index].isCompleted() ? "btn btn-sm btn-success" : "btn btn-sm btn-danger"}'>  
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -31,7 +31,7 @@ style="background-color: white; min-height: 100px">
                     <td width="30%" class="p-2">
                         <button class="btn btn-sm btn-block p-0"
                                 data-bind='
-                                    click: function(){QuestHelper.questList()[$data.index].exit();},
+                                    click: function(){QuestHelper.questList()[$data.index].endQuest();},
                                     text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit",
                                     css: {
                                       "btn-success": QuestHelper.questList()[$data.index].isCompleted(),

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -14,44 +14,53 @@ style="background-color: white; min-height: 100px">
     <!-- List of quests -->
     <div data-bind="foreach: player.currentQuests">
         <div class="card border-bottom-0">
-            <p style="margin-bottom: 0px" data-bind="text: QuestHelper.questList()[$data.index].description"></p>
-            <div class="row justify-content-sm-center">
-                <div class="col-sm-11 col-md-8">
-                    <div class="row" style="margin-bottom: 10px">
-                        <div class="col-9" style="padding:0px; margin:0px">
-                            <div class="progress" style="margin-top:6px; padding:0px; text-align:center" 
-                                data-bind='tooltip: {title: QuestHelper.questList()[$data.index].progressText, trigger: "hover"}'>
-                                <div class="progress-bar bg-success" role="progressbar" 
-                                    data-bind="attr:{style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
-                                    aria-valuemin="0" aria-valuemax="100">
-                                </div>
+            <table>
+                <tr class="text-center">
+                    <td colspan="2" data-bind="text: QuestHelper.questList()[$data.index].description"></td>
+                </tr>
+                <tr>
+                    <td class="p-2">
+                        <div class="progress p-0">
+                            <div class="progress-bar bg-success" role="progressbar"
+                                data-bind="attr:{ style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
+                                aria-valuemin="0" aria-valuemax="100">
+                                <span data-bind="text: QuestHelper.questList()[$data.index].progressText">0/1000</span>
                             </div>
                         </div>
-                        <div class="col-3">
-                            <button style="margin:0px; padding:0px; height:20px; min-width:60px"
-                                    data-bind='
-                                        click: function(){QuestHelper.questList()[$data.index].exit();}, 
-                                        text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit", 
-                                        attr: {class: QuestHelper.questList()[$data.index].isCompleted() ? "btn btn-sm btn-success" : "btn btn-sm btn-danger"}'>  
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </td>
+                    <td width="30%" class="p-2">
+                        <button class="btn btn-sm btn-block p-0"
+                                data-bind='
+                                    click: function(){QuestHelper.questList()[$data.index].exit();},
+                                    text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit",
+                                    css: {
+                                      "btn-success": QuestHelper.questList()[$data.index].isCompleted(),
+                                      "btn-danger": !QuestHelper.questList()[$data.index].isCompleted(),
+                                    }'>
+                        </button>
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
     <div data-bind='if: (!player.tutorialComplete()) && (QuestLineHelper.tutorial.totalQuests > 0) && (QuestLineHelper.tutorial.curQuest() < QuestLineHelper.tutorial.totalQuests)'>
-        <p data-bind='text: QuestLineHelper.tutorial.curQuestObject().description'></p>
-        <div class="row justify-content-center">
-            <div class="col-10">
-                <div class="progress"
-                     data-bind='tooltip: {title: ko.pureComputed(function(){return QuestLineHelper.tutorial.curQuestObject().progressText()}), trigger: "hover"}'>
-                    <div class="progress-bar bg-success" role="progressbar"
-                         data-bind="attr:{ style: 'width:' + (QuestLineHelper.tutorial.curQuestObject().progress() * 100) + '%' }"
-                         aria-valuemin="0" aria-valuemax="100">
-                    </div>
-                </div>
-            </div>
+        <div class="card border-bottom-0">
+            <table>
+                <tr class="text-center">
+                    <td data-bind="text: QuestLineHelper.tutorial.curQuestObject().description"></td>
+                </tr>
+                <tr>
+                    <td class="p-2">
+                        <div class="progress p-0">
+                            <div class="progress-bar bg-success" role="progressbar"
+                                data-bind="attr:{ style: 'width:' + (QuestLineHelper.tutorial.curQuestObject().progress() * 100) + '%'}"
+                                aria-valuemin="0" aria-valuemax="100">
+                                <span data-bind="text: ko.pureComputed(function(){return QuestLineHelper.tutorial.curQuestObject().progressText()})">0/1000</span>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
 </div>

--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -42,10 +42,10 @@
                                         data-bind='text: " " + pointsReward'></span></td>
                                 <td class="align-middle">
                                     <button class='btn btn-primary btn-sm' 
-                                        data-bind='visible: QuestHelper.haveFreeQuestSlots() && !QuestHelper.onQuest($data.index)() && !player.completedQuestList[index](),
+                                        data-bind='visible: QuestHelper.canStartNewQuest() && !QuestHelper.onQuest($data.index)() && !player.completedQuestList[index](),
                                         click: function(){
                                             QuestHelper.beginQuest($data.index);
-                                            if (!QuestHelper.haveFreeQuestSlots()) {$("#QuestModal").modal("hide");}
+                                            if (!QuestHelper.canStartNewQuest()) {$("#QuestModal").modal("hide");}
                                         }'>
                                         Start
                                     </button>

--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -50,7 +50,7 @@
                                         Start
                                     </button>
                                     <button class='btn btn-success btn-sm' data-bind='visible: QuestHelper.onQuest($data.index)() && $data.isCompleted(),
-                                                                       click: $data.exit'>
+                                                                       click: $data.endQuest'>
                                         Claim
                                     </button>
                                     <span data-bind='visible: $data.inProgress(), text: Math.floor(progress()*100) + "%"'></span>

--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -43,7 +43,10 @@
                                 <td class="align-middle">
                                     <button class='btn btn-primary btn-sm' 
                                         data-bind='visible: QuestHelper.haveFreeQuestSlots() && !QuestHelper.onQuest($data.index)() && !player.completedQuestList[index](),
-                                        click: function(){QuestHelper.beginQuest($data.index);}'>
+                                        click: function(){
+                                            QuestHelper.beginQuest($data.index);
+                                            if (!QuestHelper.haveFreeQuestSlots()) {$("#QuestModal").modal("hide");}
+                                        }'>
                                         Start
                                     </button>
                                     <button class='btn btn-success btn-sm' data-bind='visible: QuestHelper.onQuest($data.index)() && $data.isCompleted(),

--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -3,8 +3,11 @@
         <div class="modal-content">
             <div class="modal-header">
 
-                <div class="col-2">
-                <h4>Quests</h4>
+                <div class="col-3">
+                <h5>
+                    <span class='' data-bind='text: "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
+                    </span>
+                </h5>
                 </div>
                 <div class='col-6'>
                     <div data-bind='text: "Lvl. "+player.questLevel'></div>
@@ -15,7 +18,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-2">
+                <div class="col-3">
                     <img src="assets/images/currency/questPoint.png"><span id='questPoints'
                                                                            data-bind='text: " " +player._questPoints()'></span>
                 </div>
@@ -38,13 +41,14 @@
                                 <td class="align-middle" style="text-align:left"><img src="assets/images/currency/questPoint.png"><span
                                         data-bind='text: " " + pointsReward'></span></td>
                                 <td class="align-middle">
-                                    <button class='btn btn-primary btn-sm' data-bind='visible: !player.currentQuest() && !player.completedQuestList[index](),
-                                                                       click: function(){$data.beginQuest();$("#QuestModal").modal("hide")}'>
+                                    <button class='btn btn-primary btn-sm' 
+                                        data-bind='visible: QuestHelper.haveFreeQuestSlots() && !QuestHelper.onQuest($data.index)() && !player.completedQuestList[index](),
+                                        click: function(){QuestHelper.beginQuest($data.index);}'>
                                         Start
                                     </button>
-                                    <button class='btn btn-success' data-bind='visible: player.currentQuest() && (player.currentQuest().index === $data.index) && $data.isCompleted(),
-                                                                       click: $data.claimReward;player.completedQuestList[$index](true)'>
-                                        Claim Reward
+                                    <button class='btn btn-success btn-sm' data-bind='visible: QuestHelper.onQuest($data.index)() && $data.isCompleted(),
+                                                                       click: $data.exit'>
+                                        Claim
                                     </button>
                                     <span data-bind='visible: $data.inProgress(), text: Math.floor(progress()*100) + "%"'></span>
                                     <span data-bind='visible: player.completedQuestList[index]()'>Completed</span>

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -143,7 +143,7 @@ class Game {
             let now = new Date();
             if (new Date(player._lastSeen).toLocaleDateString() !== now.toLocaleDateString()) {
                 player.questRefreshes = 0;
-                QuestHelper.quitQuest();
+                QuestHelper.quitAllQuests();
                 QuestHelper.clearQuests();
                 QuestHelper.generateQuests(player.questLevel, player.questRefreshes, now);
                 DailyDeal.generateDeals(player.maxDailyDeals, now);
@@ -183,7 +183,7 @@ class Game {
         Underground.energyTick(player._mineEnergyRegenTime())
         DailyDeal.generateDeals(player.maxDailyDeals, new Date());
         QuestHelper.generateQuests(player.questLevel, player.questRefreshes, new Date());
-        QuestHelper.loadCurrentQuest(player.currentQuest());
+        QuestHelper.loadCurrentQuests(player.currentQuests);
         if (!player.tutorialComplete()) {
             QuestLineHelper.createTutorial();
             QuestLineHelper.tutorial.resumeAt(player.tutorialProgress(), player.tutorialState);

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -157,13 +157,17 @@ class Player {
                     return ko.observable(false)
                 });
             }
-            this.currentQuest = ko.observable(savedPlayer.currentQuest);
+
+            this.currentQuests = ko.observableArray(savedPlayer.currentQuests || []);
+            for (let q of this.currentQuests()) {
+                q.initial = ko.observable(q.initial);
+            }
         } else {
             this.questRefreshes = 0;
             this.completedQuestList = Array.apply(null, Array(GameConstants.QUESTS_PER_SET)).map(() => {
                 return ko.observable(false)
             });
-            this.currentQuest = ko.observable(null);
+            this.currentQuests = ko.observableArray([]);
         }
         this._questXP = ko.observable(savedPlayer._questXP || 0);
         this._questPoints = ko.observable(savedPlayer._questPoints || 0);
@@ -222,7 +226,7 @@ class Player {
     public _questPoints: KnockoutObservable<number>;
     public _questXP: KnockoutObservable<number>;
     public _lastSeen: number;
-    public currentQuest: KnockoutObservable<any>;
+    public currentQuests: KnockoutObservableArray<any>;
     private _shinyCatches: KnockoutObservable<number>;
 
     public plotList: KnockoutObservable<Plot>[];
@@ -997,7 +1001,7 @@ class Player {
             "_questXP",
             "_questPoints",
             "_lastSeen",
-            "currentQuest",
+            "currentQuests",
             "_shinyCatches",
             "gymDefeats",
             "statistics",

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -25,7 +25,7 @@ abstract class Quest {
         this.notified = false;
     }
 
-    exit() {
+    endQuest() {
         if (this.isCompleted()) {
             player.gainQuestPoints(this.pointsReward);
             this.claimed(true);
@@ -90,7 +90,7 @@ abstract class Quest {
         this.autoComplete = true;
         this.autoCompleter = this.isCompleted.subscribe(() => {
             if (this.isCompleted()) {
-                this.exit();
+                this.endQuest();
                 this.autoCompleter.dispose();
             }
         })

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -25,11 +25,10 @@ abstract class Quest {
         this.notified = false;
     }
 
-    claimReward() {
+    exit() {
         if (this.isCompleted()) {
             player.gainQuestPoints(this.pointsReward);
             this.claimed(true);
-            player.currentQuest(null);
             if (!this.inQuestLine) player.completedQuestList[this.index](true);
             let oldLevel = player.questLevel;
             player.questXP += this.xpReward;
@@ -40,25 +39,13 @@ abstract class Quest {
                 QuestHelper.refreshQuests(true);
             }
         } else {
-            Notifier.notify("Quest not yet completed", GameConstants.NotificationOption.warning);
+            this.initial(null);
         }
+        player.currentQuests(player.currentQuests().filter(x => x.index != this.index));
     }
 
     beginQuest() {
-        if (!player.currentQuest()){
-            this.initial(this.questFocus());
-            player.currentQuest({
-                index: this.index,
-                initial: this.initial()
-            });
-        } else {
-            Notifier.notify("You have already started a quest", GameConstants.NotificationOption.warning);
-        }
-    }
-
-    quit() {
-        this.initial(null);
-        player.currentQuest(null);
+        this.initial(this.questFocus());
     }
 
     set questFocus(value: KnockoutObservable<any>) {
@@ -103,7 +90,7 @@ abstract class Quest {
         this.autoComplete = true;
         this.autoCompleter = this.isCompleted.subscribe(() => {
             if (this.isCompleted()) {
-                this.claimReward();
+                this.exit();
                 this.autoCompleter.dispose();
             }
         })
@@ -111,7 +98,8 @@ abstract class Quest {
 
     inProgress() {
         return ko.computed(() => {
-            return player.currentQuest() && (this.index == player.currentQuest().index) && !this.isCompleted();
+            return player.currentQuests().map(x => x.index).includes(this.index) 
+                && !this.isCompleted();
         })
     }
 }

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -159,7 +159,7 @@ class QuestHelper{
     public static quitAllQuests() {
         let questIndexArr = player.currentQuests().map(x => x.index);
         questIndexArr.forEach(index => {
-            this.questList()[index].exit();
+            this.questList()[index].endQuest();
         });
     }
 

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -135,8 +135,20 @@ class QuestHelper{
         return Math.floor(n + 1);
     }
 
-    public static haveFreeQuestSlots(): boolean {
-        return player.currentQuests().length < this.questSlots()();
+    public static canStartNewQuest(): boolean {
+        // Two conditions for starting new quest:
+        // 1. Current quests not exceed maximum slots
+        // 2. At least one quest is neither completed nor in-progress
+        if (player.currentQuests().length >= this.questSlots()()) {
+            return false;
+        }
+        for (let i = 0; i < QuestHelper.questList().length; i++) {
+            if (!(player.completedQuestList[i]() || QuestHelper.questList()[i].isCompleted() 
+                    || QuestHelper.questList()[i].inProgress()())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static onQuest(index: number): KnockoutObservable<boolean> {
@@ -144,7 +156,7 @@ class QuestHelper{
     }
 
     public static beginQuest(index: number) {
-        if (this.haveFreeQuestSlots()) {
+        if (this.canStartNewQuest()) {
             this.questList()[index].beginQuest();
             player.currentQuests.push({
                 index: index,

--- a/src/styles/quest.less
+++ b/src/styles/quest.less
@@ -17,3 +17,17 @@
 .questReward {
   vertical-align: middle;
 }
+
+#questDisplayContainer {
+  .progress {
+    position: relative;
+  }
+  .progress .progress-bar span {
+    text-align: center;
+    position: absolute;
+    display: block;
+    color:#333;
+    width: 100%;
+    line-height: 1rem;
+  }
+}


### PR DESCRIPTION
Refer original PR https://github.com/Ishadijcks/pokeclicker/pull/339
> Number of quest slots is hard-coded to 1. But this can be easily modified with the `QuestHelper.questSlots` function.
> 
> These screenshots are taken with the case of 2 quest slots allowed:
> 
> **Main page display**
> ![image](https://user-images.githubusercontent.com/36806183/58846959-1e46b700-864f-11e9-8d40-d2f65c1d6090.png)
> 
> **Quest modal (can start more quests when one is already in progress)**
> ![image](https://user-images.githubusercontent.com/36806183/58846985-3cacb280-864f-11e9-8df2-d5a8afdd473e.png)
> 
> **Summary of code design changes:**
> 
> * Have `player.currentQuests` be a observableArray that tracks active quests
> * Move logic to check whether quests are available into `QuestHelper.ts`.
> * In `Quest.ts`, combine `quit` and `claimReward` functions into a single `exit` function, that either quits or claims reward based on quest completion status.

