### PR TITLE
[Oak Items] Show amount of actions required

### DIFF
--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -485,19 +485,23 @@
     <rect class="city" data-town="Pokemon Day Care"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="345" y="110.7"
-          data-bind="click:function(){BreedingHelper.openBreedingModal()}"></rect>
+          data-bind="click:function(){BreedingHelper.openBreedingModal()},
+          attr: { class: MapHelper.calculateTownCssClass('Mystery egg') }"></rect>
      <rect class="city" data-town="Safari Zone"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="292" y="300.7"
-          data-bind="click:function(){Safari.openModal()}"></rect>
+          data-bind="click:function(){Safari.openModal()},
+          attr: { class: MapHelper.calculateTownCssClass('Safari ticket') }"></rect>
     <rect class="city" data-town="Underground Entrance"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="380" y="240.7"
-          data-bind="click:function(){Underground.openUndergroundModal()}"></rect>
+          data-bind="click:function(){Underground.openUndergroundModal()},
+          attr: { class: MapHelper.calculateTownCssClass('Explorer kit') }"></rect>
     <rect class="city" data-town="Farm"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="373" y="293.7"
-          data-bind="click:function(){FarmRunner.openFarmModal()}"></rect>
+          data-bind="click:function(){FarmRunner.openFarmModal()},
+          attr: { class: MapHelper.calculateTownCssClass('Wailmer pail') }"></rect>
     <rect class="city" data-town="Dock"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="325" y="240"

--- a/src/scripts/oakitems/OakItem.ts
+++ b/src/scripts/oakitems/OakItem.ts
@@ -36,12 +36,12 @@ class OakItem {
 
     public getNormalizedPlayerExp() {
         let previousExp = GameConstants.OAKITEM_XP_REQUIREMENT[this.level() - 1] || 0;
-        return player.getOakItemExp(this.id) - previousExp;
+        return Math.floor((player.getOakItemExp(this.id) - previousExp) / this.expGain);
     }
 
     public getNormalizedRequiredExp() {
         let previousExp = GameConstants.OAKITEM_XP_REQUIREMENT[this.level() - 1] || 0;
-        return GameConstants.OAKITEM_XP_REQUIREMENT[this.level()] - previousExp;
+        return Math.ceil((GameConstants.OAKITEM_XP_REQUIREMENT[this.level()] - previousExp) / this.expGain);
     }
 
     public use() {

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -54,6 +54,9 @@ class MapHelper {
     }
 
     public static calculateTownCssClass(town: string): string {
+        if (player.hasKeyItem(town)) {
+            return "city unlockedTown";
+        }
         if (player.currentTown() == town) {
             return "city currentTown";
         }
@@ -74,6 +77,7 @@ class MapHelper {
 
     public static accessToTown(townName: string): boolean {
         let town = TownList[townName];
+        if (!town) return false;
         return town.isUnlocked();
     };
 


### PR DESCRIPTION
Show amount of actions required to reach next level:
![image](https://user-images.githubusercontent.com/7288322/63254396-c9b6ed80-c2c7-11e9-82da-bd8731354ef4.png)
![image](https://user-images.githubusercontent.com/7288322/63254424-dafffa00-c2c7-11e9-9a24-c0a31e30a053.png)

This still uses the same exp amounts, just the display is changed.

Show areas as unlocked once required oak item has been obtained:
![image](https://user-images.githubusercontent.com/7288322/63257675-6bd9d400-c2ce-11e9-9df4-771542487a80.png)
