### PR TITLE
Add gen2 Pokemon to eggs

### DIFF
--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -73,7 +73,8 @@ class BreedingHelper {
     }
 
     public static createTypedEgg(type: GameConstants.EggType): Egg {
-        let name = HatchList[type][Math.floor(Math.random() * HatchList[type].length)];
+        let region = player.highestRegion;
+        let name = HatchList[type][region][Math.floor(Math.random() * HatchList[type][region].length)];
         return BreedingHelper.createEgg(name, type);
     }
 
@@ -113,13 +114,25 @@ class BreedingHelper {
     }
 }
 
-const HatchList: { [name: number]: string[] } = {};
-HatchList[GameConstants.EggType.Fire] = ["Charmander", "Vulpix", "Growlithe", "Ponyta"];
-HatchList[GameConstants.EggType.Water] = ["Squirtle", "Lapras", "Staryu", "Psyduck"];
-HatchList[GameConstants.EggType.Grass] = ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"];
-HatchList[GameConstants.EggType.Fighting] = ["Hitmonlee", "Hitmonchan", "Machop", "Mankey"];
-HatchList[GameConstants.EggType.Electric] = ["Magnemite", "Pikachu", "Voltorb", "Electabuzz"];
-HatchList[GameConstants.EggType.Dragon] = ["Dratini", "Dragonair", "Dragonite"];
+const HatchList: { [name: number]: string[][] } = {};
+HatchList[GameConstants.EggType.Fire] = [
+    ["Charmander", "Vulpix", "Growlithe", "Ponyta"],
+    ["Cyndaquil", "Slugma", "Growlithe", "Houndour"]];
+HatchList[GameConstants.EggType.Water] = [
+    ["Squirtle", "Lapras", "Staryu", "Psyduck"],
+    ["Totodile", "Wooper", "Marill", "Qwilfish"]];
+HatchList[GameConstants.EggType.Grass] = [
+    ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"],
+    ["Chikorita", "Hoppip", "Sunkern", "Bellsprout"]];
+HatchList[GameConstants.EggType.Fighting] = [
+    ["Hitmonlee", "Hitmonchan", "Machop", "Mankey"],
+    ["Hitmonlee", "Hitmonchan", "Machop", "Hitmontop"]];
+HatchList[GameConstants.EggType.Electric] = [
+    ["Magnemite", "Pikachu", "Voltorb", "Electabuzz"],
+    ["Chinchou", "Mareep", "Magnemite", "Voltorb"]];
+HatchList[GameConstants.EggType.Dragon] = [
+    ["Dratini", "Dragonair", "Dragonite"],
+    ["Dratini", "Dragonair", "Dragonite"]];
 
 document.addEventListener("DOMContentLoaded", function (event) {
 

--- a/src/scripts/wildBattle/PokemonsPerRoute.ts
+++ b/src/scripts/wildBattle/PokemonsPerRoute.ts
@@ -143,7 +143,7 @@ const pokemonsPerRoute = {
             headbutt: ["Exeggcute", "Hoothoot", "Ledyba", "Spinarak", "Pineco"]
         },
         28: {
-            land: ["Ponyta", "Tangela", "Donphan", "Ursaring", "Rapidash", "Doduo", "Dodrio", "Sneasel", "Murkrow", "Sunkern", "Slugma", "Houndour"],
+            land: ["Ponyta", "Tangela", "Donphan", "Ursaring", "Rapidash", "Doduo", "Dodrio", "Sneasel", "Murkrow"],
             water: ["Poliwag", "Poliwhirl", "Magikarp"],
             headbutt: ["Natu", "Aipom", "Heracross"]
         },


### PR DESCRIPTION
refer https://github.com/Ishadijcks/pokeclicker/pull/374

> Have typed eggs' Pokemon list depend on player's highest region. This makes all gen 2 starters obtainable.
> 
> Also moved some Pokemon from Route 28 to typed eggs.
>In Pokemon Gold/Silver, these Pokemon were obtainable from routes in the Kanto map.