### PR TITLE
Update the shop

### DIFF
--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -14,7 +14,7 @@
                          <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
                          <div data-bind="if: $data.isAvailable()">
                               <img src="" class="currencyImage" data-bind="attr:{ src: 'assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
-                              <span data-bind="text: totalPrice(ShopHandler.amount())">Price</span>
+                              <span data-bind="text: totalPrice(ShopHandler.amount()).toLocaleString('en-US')">Price</span>
                           </div>
                           <div data-bind="ifnot: $data.isAvailable()">
                               <span>Sold Out</span>
@@ -33,7 +33,7 @@
                                      type="button"
                                      onclick="ShopHandler.increaseAmount(-10)">-10
                              </button>
-                             <button class="btn btn-danger btn-outline-dark smallButton smallFont"
+                             <button class="btn btn-primary btn-outline-dark smallButton smallFont"
                                      onclick="ShopHandler.resetAmount()">1
                              </button>
                            </div>
@@ -48,6 +48,10 @@
                                <button class="btn btn-secondary smallButton smallFont"
                                        type="button"
                                        onclick="ShopHandler.increaseAmount(100)">+100
+                               </button>
+                               <button class="btn btn-primary smallButton smallFont"
+                                       type="button"
+                                       onclick="ShopHandler.maxAmount()">Max
                                </button>
                                <button class="btn-outline-dark" data-bind="attr: {class: ShopHandler.calculateButtonCss()}"
                                        onclick="ShopHandler.buyItem()">Buy

--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -8,19 +8,17 @@
             </div>
             <div class="modal-body">
               <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
-                 <div class="col-sm-3">
-                     <div data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
-                         <img src="" height="36px" data-bind="attr:{ src: 'assets/images/items/' + name() + '.png' }">
-                         <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
-                         <div data-bind="if: $data.isAvailable()">
-                              <img src="" class="currencyImage" data-bind="attr:{ src: 'assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
-                              <span data-bind="text: totalPrice(ShopHandler.amount()).toLocaleString('en-US')">Price</span>
-                          </div>
-                          <div data-bind="ifnot: $data.isAvailable()">
-                              <span>Sold Out</span>
-                          </div>
-                     </div>
-                  </div>
+                 <button class="col-sm-3 shopItem clickable btn btn-secondary" data-bind="click: function() {ShopHandler.setSelected($index())}, css: { active: ShopHandler.selected() == $index()}">
+                     <img src="" height="36px" data-bind="attr:{ src: 'assets/images/items/' + name() + '.png' }">
+                     <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
+                     <div data-bind="if: $data.isAvailable()">
+                          <img src="" class="currencyImage" data-bind="attr:{ src: 'assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
+                          <span data-bind="text: totalPrice(ShopHandler.amount()).toLocaleString('en-US')">Price</span>
+                      </div>
+                      <div data-bind="ifnot: $data.isAvailable()">
+                          <span>Sold Out</span>
+                      </div>
+                  </button>
                 </div>
                 <div class="row justify-content-center">
                    <div class="col-11 col-sm-10 col-md-11">

--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -7,18 +7,23 @@
                 <button type="button" class="btn btn-primary" data-dismiss="modal">&times;</button>
             </div>
             <div class="modal-body">
-              <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
-                 <button class="col-sm-3 shopItem clickable btn btn-secondary" data-bind="click: function() {ShopHandler.setSelected($index())}, css: { active: ShopHandler.selected() == $index()}">
-                     <img src="" height="36px" data-bind="attr:{ src: 'assets/images/items/' + name() + '.png' }">
-                     <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
-                     <div data-bind="if: $data.isAvailable()">
-                          <img src="" class="currencyImage" data-bind="attr:{ src: 'assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
-                          <span data-bind="text: totalPrice(ShopHandler.amount()).toLocaleString('en-US')">Price</span>
-                      </div>
-                      <div data-bind="ifnot: $data.isAvailable()">
-                          <span>Sold Out</span>
-                      </div>
-                  </button>
+                <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
+                    <div class="col-sm-3">
+                       <button class="shopItem clickable btn btn-block btn-secondary"
+                           data-bind="click: function() {ShopHandler.setSelected($index())},
+                           css: { active: ShopHandler.selected() == $index() },
+                           attr: { disabled: !$data.isAvailable() }">
+                           <img src="" height="36px" data-bind="attr:{ src: 'assets/images/items/' + name() + '.png' }">
+                           <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
+                           <div data-bind="if: $data.isAvailable()">
+                                <img src="" class="currencyImage" data-bind="attr:{ src: 'assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
+                                <span data-bind="text: totalPrice(ShopHandler.amount()).toLocaleString('en-US')">Price</span>
+                            </div>
+                            <div data-bind="ifnot: $data.isAvailable()">
+                                <span>Sold Out</span>
+                            </div>
+                        </button>
+                    </div>
                 </div>
                 <div class="row justify-content-center">
                    <div class="col-11 col-sm-10 col-md-11">

--- a/src/index.html
+++ b/src/index.html
@@ -438,11 +438,11 @@
                             </div>
                         </div>
                     </div>
+                    <!--TownView-->
+
+                    @import "townView.html"
                 </div>
 
-                <!--TownView-->
-
-                @import "townView.html"
 
                 <!--GymView-->
                 @import "gymView.html"

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -39,8 +39,8 @@ namespace GameConstants {
     export const SHINY_CHANCE_STONE = 4096;
     export const SHINY_CHANCE_SAFARI = 2048;
 
-    export const ITEM_PRICE_MULTIPLIER = 1.01;
-    export const ITEM_PRICE_DEDUCT = 1.008;
+    export const ITEM_PRICE_MULTIPLIER = 1.001;
+    export const ITEM_PRICE_DEDUCT = 1.0005;
 
 
 

--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -15,7 +15,7 @@ abstract class Item {
 
     totalPrice(amount: number): number {
         if (this.name() == GameConstants.Pokeball[GameConstants.Pokeball.Pokeball]) {
-            return this.price() * amount;
+            return this.basePrice * amount;
         } else {
             let res = (this.price() * (1 - Math.pow(GameConstants.ITEM_PRICE_MULTIPLIER, amount))) / (1 - GameConstants.ITEM_PRICE_MULTIPLIER);
             return Math.floor(res);

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -5,7 +5,8 @@ class ShopHandler {
     static amount: KnockoutObservable<number> = ko.observable(1);
 
     public static showShop(shop: Shop) {
-        ShopHandler.amount(1);
+        this.setSelected(0);
+        this.resetAmount();
         this.shopObservable(shop);
 
         for (let i = 0; i < shop.items().length; i++) {

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -35,6 +35,18 @@ class ShopHandler {
         input.val(newVal > 1 ? newVal : 1).change();
     }
 
+    public static maxAmount(n: number) {
+        const item: Item = this.shopObservable().items()[ShopHandler.selected()];
+        const input = $("input[name='amountOfItems']");
+
+        if (!item || !item.isAvailable()){
+          return input.val(0).change();
+        }
+        let amt = 1;
+        for (amt; player.hasCurrency(item.totalPrice(amt), item.currency); amt++){}
+        input.val(--amt).change();
+    }
+
     public static calculateCss(i: number): string {
         if (this.selected() == i) {
             return "shopItem clickable btn btn-secondary active"

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -126,7 +126,8 @@ TownList["Cerulean Cave"] = new DungeonTown("Cerulean Cave", [4], GameConstants.
 TownList["Pokemon Mansion"] = new DungeonTown("Pokemon Mansion", [20], GameConstants.Badge.Soul);
 
 //Johto Towns
-TownList["New Bark Town"] = new Town("New Bark Town", []);
+let NewBarkTownShop = new Shop(["Pokeball"]);
+TownList["New Bark Town"] = new Town("New Bark Town", [], NewBarkTownShop);
 
 TownList["Cherrygrove City"] = new Town("Cherrygrove City", [29]);
 

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -129,7 +129,8 @@ TownList["Pokemon Mansion"] = new DungeonTown("Pokemon Mansion", [20], GameConst
 let NewBarkTownShop = new Shop(["Pokeball"]);
 TownList["New Bark Town"] = new Town("New Bark Town", [], NewBarkTownShop);
 
-TownList["Cherrygrove City"] = new Town("Cherrygrove City", [29]);
+let CherrygroveCityShop = new Shop(["Greatball"]);
+TownList["Cherrygrove City"] = new Town("Cherrygrove City", [29], CherrygroveCityShop);
 
 let VioletCityShop = new Shop(["MediumRestore", "Togepi"]);
 TownList["Violet City"] = new Town("Violet City", [31], VioletCityShop, dungeonList["Sprout Tower"]);


### PR DESCRIPTION
Closes #33 
Closes #36 

- Add max amount button
- Reduce the item cost multiplier
- Make Pokeball item cost never increase
- Update the look of the shop
- Reset shop to have first item selected and amount as 1 when you open it
- Disable ability to click on unavailable items
- Add formatting to shop cost (`1,000,000`)
- Fix spacing for wider towns
- Add Pokeballs to New Bark Town
- Add Greatballs to Cherrygrove City