### PR TITLE
Breeding & Crobat, Suicune, Shuckle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -483,7 +483,7 @@
 
             <div data-bind="if:KeyItemHandler.getKeyItemObservableByName('Town map')().isUnlocked()">
                 <div data-bind="if: (Game.gameState() === GameConstants.GameState.fighting || Game.gameState() === GameConstants.GameState.gym || Game.gameState() === GameConstants.GameState.town||
-                    Game.gameState() === GameConstants.GameState.shop || Game.gameState() === GameConstants.GameState.farm)">
+                    Game.gameState() === GameConstants.GameState.shop || Game.gameState() === GameConstants.GameState.farm || Game.gameState() === GameConstants.GameState.paused)">
                     <p id="mapTooltip" class="btn btn-secondary" style="visibility: hidden;"></p>
                     <div class="page-item no-select">
                         <svg id="map" viewBox="0 0 650 400" preserveAspectRatio="xMaxYMax meet">

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -28,7 +28,7 @@ namespace GameConstants {
 
     export const RoamingPokemon = {
         0: ["Mew"],
-        1: ["Raikou", "Entei"],
+        1: ["Raikou", "Entei", "Suicune"],
     }
 
     // Shinies

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -82,9 +82,19 @@ class BreedingHelper {
     }
 
     public static createTypedEgg(type: GameConstants.EggType): Egg {
-        let region = player.highestRegion;
-        let name = HatchList[type][region][Math.floor(Math.random() * HatchList[type][region].length)];
-        return BreedingHelper.createEgg(name, type);
+        const hatch_list = HatchList[type];
+        const hatchable = hatch_list.slice(0, player.highestRegion + 1);
+        let possible_hatches = [];
+        hatchable.forEach((pokemon, index)=>{
+            if (!pokemon.length) return;
+            const toAdd = possible_hatches.length || 1;
+            for (let i = 0; i < toAdd; i++){
+                possible_hatches.push(pokemon);
+            }
+        });
+        possible_hatches = possible_hatches[Math.floor(Math.random() * possible_hatches.length)];
+        const pokemon = possible_hatches[Math.floor(Math.random() * possible_hatches.length)];
+        return BreedingHelper.createEgg(pokemon, type);
     }
 
     public static createRandomEgg(): Egg {
@@ -140,22 +150,28 @@ class BreedingHelper {
 const HatchList: { [name: number]: string[][] } = {};
 HatchList[GameConstants.EggType.Fire] = [
     ["Charmander", "Vulpix", "Growlithe", "Ponyta"],
-    ["Cyndaquil", "Slugma", "Growlithe", "Houndour"]];
+    ["Cyndaquil", "Slugma", "Houndour", "Magby"],
+  ];
 HatchList[GameConstants.EggType.Water] = [
     ["Squirtle", "Lapras", "Staryu", "Psyduck"],
-    ["Totodile", "Wooper", "Marill", "Qwilfish"]];
+    ["Totodile", "Wooper", "Qwilfish"],
+  ];
 HatchList[GameConstants.EggType.Grass] = [
     ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"],
-    ["Chikorita", "Hoppip", "Sunkern", "Bellsprout"]];
+    ["Chikorita", "Hoppip", "Sunkern"],
+  ];
 HatchList[GameConstants.EggType.Fighting] = [
     ["Hitmonlee", "Hitmonchan", "Machop", "Mankey"],
-    ["Hitmonlee", "Hitmonchan", "Machop", "Hitmontop"]];
+    ["Tyrogue"],
+  ];
 HatchList[GameConstants.EggType.Electric] = [
     ["Magnemite", "Pikachu", "Voltorb", "Electabuzz"],
-    ["Chinchou", "Mareep", "Magnemite", "Voltorb"]];
+    ["Chinchou", "Mareep", "Elekid"],
+  ];
 HatchList[GameConstants.EggType.Dragon] = [
     ["Dratini", "Dragonair", "Dragonite"],
-    ["Dratini", "Dragonair", "Dragonite"]];
+    [],
+  ];
 
 document.addEventListener("DOMContentLoaded", function (event) {
 

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -160,11 +160,10 @@ HatchList[GameConstants.EggType.Dragon] = [
 document.addEventListener("DOMContentLoaded", function (event) {
 
     $('#breedingModal').on('hidden.bs.modal', function () {
-        if (player.route() == 5) {
-            Game.gameState(GameConstants.GameState.fighting);
-        } else {
+        if (player.highestRegion == 0) {
             MapHelper.moveToRoute(5, GameConstants.Region.kanto);
         }
+        MapHelper.returnToMap();
     });
 
 });

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -154,7 +154,7 @@ HatchList[GameConstants.EggType.Fire] = [
   ];
 HatchList[GameConstants.EggType.Water] = [
     ["Squirtle", "Lapras", "Staryu", "Psyduck"],
-    ["Totodile", "Wooper", "Qwilfish"],
+    ["Totodile", "Wooper", "Marill", "Qwilfish"],
   ];
 HatchList[GameConstants.EggType.Grass] = [
     ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"],

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -180,7 +180,7 @@ dungeonList["Burned Tower"] = new Dungeon("Burned Tower",
     ["Rattata", "Zubat", "Koffing", "Raticate"],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Lucky_incense],
     1500,
-    [new DungeonBossPokemon("Golbat", 6000, 35), new DungeonBossPokemon("Weezing", 6000, 35), new DungeonBossPokemon("Suicune", 300000, 50)],
+    [new DungeonBossPokemon("Golbat", 6000, 35), new DungeonBossPokemon("Weezing", 6000, 35), new DungeonBossPokemon("Shuckle", 300000, 50)],
     4500, GameConstants.Badge.Fog, 37, 20
 );
 

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -575,6 +575,8 @@ const pokemonList = [
         "id": 42,
         "name": "Golbat",
         "catchRate": 90,
+        "evolution": "Crobat",
+        "evoLevel": 100,
         "type": [
             "Poison",
             "Flying"
@@ -3371,6 +3373,6 @@ for (let i = 0; i < pokemonList.length; i++) {
     pokemonMap[p["name"]] = p;
     pokemonMapId[i + 1] = p;
     if (p.hasOwnProperty("evolution")) {
-        p["evolution"].split(", ").forEach(x => {pokemonDevolutionMap[x] = p["name"]});        
+        p["evolution"].split(", ").forEach(x => {pokemonDevolutionMap[x] = p["name"]});
     }
 }

--- a/src/scripts/wildBattle/PokemonsPerRoute.ts
+++ b/src/scripts/wildBattle/PokemonsPerRoute.ts
@@ -210,7 +210,7 @@ const pokemonsPerRoute = {
         41: {
             land: [],
             water: ["Tentacool","Tentacruel","Mantine","Magikarp", "Chinchou", "Shellder"],
-            headbutt: []
+            headbutt: ["Shuckle"]
         },
         42: {
             land: ["Spearow","Zubat","Mankey","Mareep","Flaaffy"],
@@ -249,7 +249,6 @@ const pokemonsPerRoute = {
         }
     },
     2: {
-        
+
     }
 };
-

--- a/src/scripts/wildBattle/PokemonsPerRoute.ts
+++ b/src/scripts/wildBattle/PokemonsPerRoute.ts
@@ -210,7 +210,7 @@ const pokemonsPerRoute = {
         41: {
             land: [],
             water: ["Tentacool","Tentacruel","Mantine","Magikarp", "Chinchou", "Shellder"],
-            headbutt: ["Shuckle"]
+            headbutt: []
         },
         42: {
             land: ["Spearow","Zubat","Mankey","Mareep","Flaaffy"],

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -1,18 +1,31 @@
 class MapHelper {
+    public static returnToMap(){
+      if (player.currentTown()){
+        return this.moveToTown(player.currentTown());
+      }
+      if (player.route()){
+        return this.moveToRoute(player.route(), player.region);
+      }
+    }
 
     public static moveToRoute = function (route: number, region: GameConstants.Region) {
-        if (!isNaN(route) && !(route == player.route())) {
-            if (this.accessToRoute(route, region)) {
-                player.route(route);
-                player.region = region;
-                player.currentTown('');
-                Battle.generateNewEnemy();
-                Game.gameState(GameConstants.GameState.fighting);
-                Game.applyRouteBindings();
+        if (isNaN(route)) return;
+        let genNewEnemy = false;
+        if (route != player.route()) {
+          genNewEnemy = true
+        }
+        if (this.accessToRoute(route, region)) {
+            player.route(route);
+            player.region = region;
+            player.currentTown('');
+            if (genNewEnemy){
+              Battle.generateNewEnemy();
             }
-            else {
-                Notifier.notify("You don't have access to that route yet.", GameConstants.NotificationOption.warning);
-            }
+            Game.gameState(GameConstants.GameState.fighting);
+            Game.applyRouteBindings();
+        }
+        else {
+            Notifier.notify("You don't have access to that route yet.", GameConstants.NotificationOption.warning);
         }
     };
 
@@ -83,9 +96,7 @@ class MapHelper {
 
     public static moveToTown(townName: string) {
         if (MapHelper.accessToTown(townName)) {
-            //console.log($("[data-town]"));
             Game.gameState(GameConstants.GameState.idle);
-            $("[data-route='" + player.route() + "']").removeClass('currentRoute').addClass('unlockedRoute'); //pretty sure any jquery in typescript does not work fyi
             player.route(0);
             player.town(TownList[townName]);
             player.currentTown(townName);


### PR DESCRIPTION
- Add Crobat evolution (lvl 100)
- [Burned Tower] Replace Suicune with Shuckle
- Make Suicune a roaming Pokemon
- [breeding]
  - Don't take the player back to route 5 once you reach gen 2
  - Switch up the way hatched pokemon is determined:

Kanto | Johto | Hoenn | Sinnoh | Unova
:--: | :--: | :--: | :--: | :--:
`100%` | `-` | `-` | `-` | `-`
`50%` | `50%` | `-` | `-` | `-`
`25%` | `25%` | `50%` | `-` | `-`
`12.5%` | `12.5%` | `25%` | `50%` | `-`
`6.25%` | `6.25%` | `12.5%` | `25%` | `50%`