### PR TITLE
Minor Fixes

### DIFF
--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -47,6 +47,7 @@ class Preload {
             p.push(new Promise<number>(resolve => {
                 let img = new Image();
                 img.onload = () => resolve();
+                img.onerror = () => resolve();
                 img.src = `assets/images/towns/${name}.png`;
             }));
 

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -84,6 +84,10 @@ button {
   cursor: pointer;
 }
 
+body {
+    overflow-x: hidden;
+}
+
 body:hover {
   cursor: default;
 }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -190,7 +190,6 @@ body:hover {
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* Internet Explorer/Edge */
   user-select: none; /* Non-prefixed version, currently not supported by any browser */
-  touch-action: none;
 }
 
 img {


### PR DESCRIPTION
Fix the flicker that happens when you open the start menu.
Allow the page to load correctly while pre-loading images _(if image not found)_.