### PR TITLE
Add 2 new tutorial quest

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -50,7 +50,7 @@ class QuestLineHelper {
         //Cleat Mt Moon dungeon
         let clearMtMoon = new DefeatDungeonQuest(GameConstants.KantoDungeons[2], 1);
         clearMtMoon.pointsReward = 10;
-        clearMtMoon.description = "Gather 75 Dungeon tokens by capturing Pokemon, then clear the Mt. Moon dungeon.";
+        clearMtMoon.description = 'Gather 75 Dungeon tokens by capturing Pokemon, then clear the Mt. Moon dungeon.';
         this.tutorial.addQuest(clearMtMoon);
 
         this.tutorialTracker = this.tutorial.curQuestInitial.subscribe((newInitial)=>{

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -32,8 +32,7 @@ class QuestLineHelper {
         this.tutorial.addQuest(pewter);
 
         //Buy pokeballs
-        let buyPokeballs = new BuyPokeballsQuest(30,GameConstants.Pokeball.Pokeball,50);
-        buyPokeballs.pointsReward = 50;
+        let buyPokeballs = new BuyPokeballsQuest(30, GameConstants.Pokeball.Pokeball, 50);
         buyPokeballs.description = "Buy 30 pokeballs. You can find these in the Pewter City Shop.";
         this.tutorial.addQuest(buyPokeballs);
 
@@ -41,6 +40,18 @@ class QuestLineHelper {
         let routeThree = new DefeatPokemonsQuest(3, 10);
         routeThree.pointsReward = 100;
         this.tutorial.addQuest(routeThree);
+
+        //Buy Dungeon ticket
+        let buyDungeonTicket = new Quest(1, 10);
+        buyDungeonTicket.description = 'Buy the Dungeon ticket from Pewter City Shop.';
+        buyDungeonTicket.questFocus = ()=>+player.hasKeyItem('Dungeon ticket');
+        this.tutorial.addQuest(buyDungeonTicket);
+
+        //Cleat Mt Moon dungeon
+        let clearMtMoon = new DefeatDungeonQuest(GameConstants.KantoDungeons[2], 1);
+        clearMtMoon.pointsReward = 10;
+        clearMtMoon.description = "Gather 75 Dungeon tokens by capturing Pokemon, then clear the Mt. Moon dungeon.";
+        this.tutorial.addQuest(clearMtMoon);
 
         this.tutorialTracker = this.tutorial.curQuestInitial.subscribe((newInitial)=>{
             player.tutorialProgress(QuestLineHelper.tutorial.curQuest());

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -201,11 +201,11 @@ class SafariBattle {
     }
 
     private static lockButtons() {
-      $('.safariOption button').attr('disabled', true);
+      $('.safariOption button').attr('disabled', 'true');
     }
 
     private static unlockButtons() {
-      $('.safariOption button').attr('disabled', false);
+      $('.safariOption button').attr('disabled', null);
     }
 
     private static endBattle() {


### PR DESCRIPTION
Not sure if this was an issue,
But i've added 2 new tutorial quest:
`Buy the Dungeon ticket from Pewter City Shop.`
`Gather 75 Dungeon tokens by capturing Pokemon, then clear the Mt. Moon dungeon.`

This should hopefully help out new players who are unsure how to progress from that point.